### PR TITLE
Fix #70: Allow selecting default file encoding

### DIFF
--- a/src/DaxStudio.UI/DaxStudio.UI.csproj
+++ b/src/DaxStudio.UI/DaxStudio.UI.csproj
@@ -218,6 +218,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />

--- a/src/DaxStudio.UI/ViewModels/DocumentViewModel.cs
+++ b/src/DaxStudio.UI/ViewModels/DocumentViewModel.cs
@@ -39,6 +39,7 @@ using Newtonsoft.Json;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.IO.Compression;
+using System.Configuration;
 
 namespace DaxStudio.UI.ViewModels
 {
@@ -1570,7 +1571,10 @@ namespace DaxStudio.UI.ViewModels
                 SaveAs();
             else
             {
-                using (TextWriter tw = new StreamWriter(FileName, false, Encoding.Unicode))
+                var encodingName = ConfigurationManager.AppSettings["FileEditor.Encoding"];
+                var encoding = string.IsNullOrEmpty(encodingName) ? Encoding.Unicode : Encoding.GetEncoding(encodingName);
+
+                using (TextWriter tw = new StreamWriter(FileName, false, encoding))
                 {
                     tw.Write(GetEditor().Text);
                     tw.Close();


### PR DESCRIPTION
A new `FileEditor.Encoding` appsetting can be added to `DaxStudio.exe.config` file to specify file save encoding. A list of encoding names can be found [here](https://msdn.microsoft.com/en-us/library/system.text.encoding.getencodings(v=vs.110).aspx). If the setting is missing it will default to saving files in `Encoding.Unicode`.

To save files in UTF8 add the following to `DaxStudio.exe.config`:

```xml
<add key="FileEditor.Encoding" value="utf-8" />
```