### PR TITLE
Fixes #118

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,13 @@
+Building Dax Studio
+===================
+
+Before attempting to build DAX Studio, you will need to run the powershell 
+script, `setup-build-env.ps1`, located in the root of the repository.
+
+This script attempts to find a few of binary dependencies and copies them to a
+local 'lib' folder.  These dependencies are:
+
+    Microsoft.AnalysisServices.AdomdClient.dll
+    Microsoft.Excel.AdomdClient.dll
+    Microsoft.Excel.Amo.dll
+

--- a/setup-build-env.ps1
+++ b/setup-build-env.ps1
@@ -18,8 +18,10 @@ $requiredDlls = @("Microsoft.Excel.AdomdClient.dll"
 $searchFolders = @("${Env:ProgramFiles(x86)}\Common Files\Microsoft Shared\Office15\DataModel\"
 , "$Env:ProgramFiles\Microsoft Office 15\root\vfs\ProgramFilesCommonX86\Microsoft Shared\OFFICE15\DataModel\"
 , "$Env:ProgramFiles\Common Files\microsoft shared\OFFICE15\DataModel"
+, "$Env:ProgramFiles\Common Files\microsoft shared\OFFICE16\DataModel"
 , "$Env:ProgramFiles\Microsoft.NET\ADOMD.NET\110\"
 , "$Env:ProgramFiles\Microsoft.NET\ADOMD.NET\120\"
+, "$Env:ProgramFiles\Microsoft.NET\ADOMD.NET\150\"
 )
 
 ## 1. Create lib subfolder

--- a/src/DaxStudio.ExcelAddin/DaxStudio.ExcelAddin.csproj
+++ b/src/DaxStudio.ExcelAddin/DaxStudio.ExcelAddin.csproj
@@ -536,7 +536,7 @@
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
   <!-- transofrm the config file so that logging in the app.debug.config is removed when we do a release build -->
-  <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v14.0\Web\Microsoft.Web.Publishing.Tasks.dll" />
+  <UsingTask TaskName="TransformXml" AssemblyFile="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Web\Microsoft.Web.Publishing.Tasks.dll" />
   <Target Name="AfterBuild">
     <TransformXml Source="app.config" Transform="app.$(Configuration).config" Destination="$(OutputPath)\$(AssemblyName).dll.config" />
   </Target>


### PR DESCRIPTION
- Added additional paths to setup-build-env.ps1 for newer versions
- Generalized msbuild path for Microsoft.Web.Publishing.Targets
- Added readme.md to document need to run setup-build-env

Office 2016 needed the OFFICE16 path.