### PR TITLE
Fixing "New" creating two new files.

### DIFF
--- a/src/DaxStudio.UI/Views/RibbonView.xaml
+++ b/src/DaxStudio.UI/Views/RibbonView.xaml
@@ -120,13 +120,6 @@
                                    HorizontalContentAlignment="Left" 
                                    Foreground="White"
                                    Icon="{StaticResource NewIconSmall}">
-                        <i:Interaction.Triggers>
-                            <i:EventTrigger EventName="Click">
-                                <cal:ActionMessage MethodName="NewQuery">
-
-                                </cal:ActionMessage>
-                            </i:EventTrigger>
-                        </i:Interaction.Triggers>
                     </Fluent:Button>
 
                     <Fluent:BackstageTabItem Header="Open"  >


### PR DESCRIPTION
Now only creates one tab/file.
Previously, pressing "New" in the "File" menu would create two new tabs/files, rather than one; and would trigger a further bug such that only one of these tabs would be connected to a database.