### PR TITLE
Buttons which aren't the default "OK" or "Cancel" buttons should have…

### DIFF
--- a/src/DaxStudio.UI/Views/AutoSaveRecoverDialogView.xaml
+++ b/src/DaxStudio.UI/Views/AutoSaveRecoverDialogView.xaml
@@ -94,7 +94,7 @@
                       cal:Message.Attach="[Event MouseUp] = [Action ToggleShouldOpen($this.SelectedItem)]">
             </ListView>
             <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="7,5" HorizontalAlignment="Right">
-                <Button x:Name="Open">Open</Button>
+                <Button x:Name="_Open" IsDefault="True">Open</Button>
                 <Button x:Name="Cancel" IsCancel="True">Cancel</Button>
             </StackPanel>
         </Grid>

--- a/src/DaxStudio.UI/Views/AutoSaveRecoverDialogView.xaml
+++ b/src/DaxStudio.UI/Views/AutoSaveRecoverDialogView.xaml
@@ -94,7 +94,7 @@
                       cal:Message.Attach="[Event MouseUp] = [Action ToggleShouldOpen($this.SelectedItem)]">
             </ListView>
             <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="7,5" HorizontalAlignment="Right">
-                <Button x:Name="_Open" IsDefault="True">Open</Button>
+                <Button x:Name="Open" IsDefault="True">_Open</Button>
                 <Button x:Name="Cancel" IsCancel="True">Cancel</Button>
             </StackPanel>
         </Grid>

--- a/src/DaxStudio.UI/Views/ExportDataDialogView.xaml
+++ b/src/DaxStudio.UI/Views/ExportDataDialogView.xaml
@@ -66,7 +66,7 @@
                 <CheckBox IsChecked="{Binding TruncateTables}">Truncate Tables</CheckBox>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="7,5" HorizontalAlignment="Right">
-                <Button x:Name="Export">Export</Button>
+                <Button x:Name="Export" IsDefault="True">_Export</Button>
                 <Button x:Name="Cancel" IsCancel="True">Cancel</Button>
             </StackPanel>
         </Grid>

--- a/src/DaxStudio.UI/Views/GotoLineDialogView.xaml
+++ b/src/DaxStudio.UI/Views/GotoLineDialogView.xaml
@@ -60,7 +60,7 @@
                 </StackPanel>
                 <!-- Buttons -->
                 <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" HorizontalAlignment="Right" VerticalAlignment="Bottom">
-                <Button x:Name="GotoLine" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Right" Padding="5px 2px" Margin="2px" Content="Goto" IsDefault="True">
+                <Button x:Name="GotoLine" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Right" Padding="5px 2px" Margin="2px" Content="_Goto" IsDefault="True">
                     <Button.Style>
                         <Style TargetType="Button">
                             <Setter Property="IsEnabled" Value="False"/>

--- a/src/DaxStudio.UI/Views/HelpAboutView.xaml
+++ b/src/DaxStudio.UI/Views/HelpAboutView.xaml
@@ -120,7 +120,7 @@
 			Opacity="0"       />
                 
                 <StackPanel Orientation="Horizontal" Grid.Row="3" HorizontalAlignment="Right" Margin="0,0,5,5">
-            <Button x:Name="Ok" Width="75" Height="23" Content="Ok" IsDefault="True" IsCancel="True"/>
+            <Button x:Name="Ok" Width="75" Height="23" Content="OK" IsDefault="True" IsCancel="True"/>
         </StackPanel>
 
     </Grid>

--- a/src/DaxStudio.UI/Views/QueryParametersDialogView.xaml
+++ b/src/DaxStudio.UI/Views/QueryParametersDialogView.xaml
@@ -149,10 +149,10 @@
                 </ListView.View>
  
             </ListView>-->
-            <Button x:Name="WriteParameterXml" IsDefault="True" Grid.Row="3" Margin="9,7" Width="140" HorizontalAlignment="Left" TabIndex="4">Write Parameter XML</Button>
+            <Button x:Name="WriteParameterXml" IsDefault="True" Grid.Row="3" Margin="9,7" Width="140" HorizontalAlignment="Left" TabIndex="4">_Write Parameter XML</Button>
             <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="7,5" HorizontalAlignment="Right">
                 
-                <Button x:Name="Ok" IsDefault="True" TabIndex="1">Ok</Button>
+                <Button x:Name="OK" IsDefault="True" TabIndex="1">Ok</Button>
                 <Button x:Name="Cancel" IsCancel="True" TabIndex="2">Cancel</Button>
             </StackPanel>
         </Grid>

--- a/src/DaxStudio.UI/Views/SaveDialogView.xaml
+++ b/src/DaxStudio.UI/Views/SaveDialogView.xaml
@@ -67,8 +67,8 @@
                       cal:Message.Attach="[Event MouseUp] = [Action ToggleShouldSave($this.SelectedItem)]">
             </ListView>
             <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="7,5" HorizontalAlignment="Right">
-                <Button x:Name="Save">Save</Button>
-                <Button x:Name="DontSave">Don't Save</Button>
+                <Button x:Name="Save">_Save</Button>
+                <Button x:Name="DontSave" >Do_n't Save</Button>
                 <Button x:Name="Cancel" IsCancel="True">Cancel</Button>
             </StackPanel>
         </Grid>


### PR DESCRIPTION
It's not currently possible to dismiss common dialogs or perform actions without using the mouse.  This PR adds an AccessKey for those dialogs.  The Windows convention seems to be that all buttons other than "OK" and "Cancel" need to have an AccessKey specified.  The convention for "OK" is <ENTER>, "Cancel" is <esc>, and of course both need to be IsDefault=True and IsCancel=True respectively.

https://ux.stackexchange.com/questions/82362/is-ok-button-with-access-key-acceptable

