### PR TITLE
Fix for disabling Intellisense when not connected

### DIFF
--- a/src/DaxStudio.UI/Utils/Intellisense/DaxIntellisenseProvider.cs
+++ b/src/DaxStudio.UI/Utils/Intellisense/DaxIntellisenseProvider.cs
@@ -242,7 +242,7 @@ namespace DaxStudio.UI.Utils
             //if (!funcName.EndsWith("(")) return;
             funcName = funcName.TrimEnd('(');
 
-            ADOTabularFunction f = Document.Connection.FunctionGroups.GetByName(funcName);
+            ADOTabularFunction f = Document?.Connection?.FunctionGroups?.GetByName(funcName);
             
             if (f != null)
             {


### PR DESCRIPTION
User opens a .dax file, attempts to edit the file, intellisense code is invoked, an Object Reference Not Set... exception is thrown due to the lack of a connection, and Intellisense is disabled for the entire window.  Instead, use the already existing null check to simply not attempt to show the Intellisense window, and when a connection is made later, Intellisense will work.