### PR TITLE
Checker - minor fix for NullReferenceException when disposing RegistryKey

### DIFF
--- a/src/DaxStudio.Checker/Checker.cs
+++ b/src/DaxStudio.Checker/Checker.cs
@@ -388,7 +388,7 @@ namespace DaxStudio.CheckerApp
                 }
                 finally
                 {
-                    xlKey.Dispose();
+                    xlKey?.Dispose();
                 }
             }
             finally {


### PR DESCRIPTION
Fix NullReferenceException when disposing RegistryKey if ExcelAddIn is not installed