### PR TITLE
set the ReferencedAssemblies DataGrid to read-only

### DIFF
--- a/src/DaxStudio.UI/Views/HelpAboutView.xaml
+++ b/src/DaxStudio.UI/Views/HelpAboutView.xaml
@@ -105,7 +105,7 @@
             <TabItem Header="Components" Height="32" FontSize="12">
                 <ctrl:ClipBorder CornerRadius="8" BorderBrush="{DynamicResource Theme.Brush.Control.Border}" BorderThickness="1">
                 <DataGrid x:Name="ReferencedAssemblies" 
-		          
+                          IsReadOnly="True"
 		          ClipboardCopyMode="IncludeHeader"
 		          SelectionMode="Single"       
 		          BorderBrush="DarkGray"


### PR DESCRIPTION
So that double-clicking on DataGridCells will not crash the app.