### PR TITLE
Update ODC name in OdcHelper.cs

### DIFF
--- a/src/DaxStudio.UI/Utils/OdcHelper.cs
+++ b/src/DaxStudio.UI/Utils/OdcHelper.cs
@@ -67,7 +67,7 @@ xmlns=""http://www.w3.org/TR/REC-html40"">
 <xml id=docprops><o:DocumentProperties
   xmlns:o=""urn:schemas-microsoft-com:office:office""
   xmlns=""http://www.w3.org/TR/REC-html40"">
-  <o:Name>mtbsql608v-dev_mssqlinst01 PRS Model</o:Name>
+  <o:Name>DAX Studio Analyze in Excel PowerBI Model</o:Name>
  </o:DocumentProperties>
 </xml>";
         private static string odcBody = @"<xml id=msodc><odc:OfficeDataConnection


### PR DESCRIPTION
When using Analyze in Excel, the connection name was set to "mtbsql608v-dev_mssqlinst01 PRS Model", which is confusing and sounds like the name of a local model from our appreciated DaxStudio devs. Suggesting to change it to "DAX Studio Analyze in Excel PowerBI Model" to make it easier to understand. Thanks!