### PR TITLE
Add `benchmark` command to dscmd CLI

### DIFF
--- a/src/DaxStudio.CommandLine/Commands/BenchmarkCommand.cs
+++ b/src/DaxStudio.CommandLine/Commands/BenchmarkCommand.cs
@@ -4,6 +4,7 @@ using DaxStudio.CommandLine.ViewModel;
 using DaxStudio.Interfaces;
 using DaxStudio.QueryTrace;
 using DaxStudio.QueryTrace.Interfaces;
+using DaxStudio.UI.Interfaces;
 using DaxStudio.UI.Events;
 using DaxStudio.UI.Model;
 using DaxStudio.UI.ViewModels;
@@ -49,6 +50,14 @@ namespace DaxStudio.CommandLine.Commands
             [Description("Suppress console output (only write CSV)")]
             [DefaultValue(false)]
             public bool Silent { get; set; }
+
+            [CommandOption("--role <role>")]
+            [Description("RLS role to test (adds Roles= to the query connection string)")]
+            public string Role { get; set; }
+
+            [CommandOption("--effective-user <upn>")]
+            [Description("User to impersonate for RLS testing (adds EffectiveUserName= to the query connection string)")]
+            public string EffectiveUser { get; set; }
         }
 
         public IEventAggregator EventAggregator { get; }
@@ -107,10 +116,27 @@ namespace DaxStudio.CommandLine.Commands
             }
 
             // Connect — same pattern as CustomTraceCommand (lines 98-110)
+            // Roles/EffectiveUserName are added to the query connection for RLS testing.
+            // ClearCache requires admin privileges, so it uses the base connection
+            // (without role impersonation) via a separate ConnectionManager.
+            string baseConnectionString = settings.FullConnectionString;
+            string queryConnectionString = baseConnectionString;
+            bool hasImpersonation = false;
+            if (!string.IsNullOrWhiteSpace(settings.Role))
+            {
+                queryConnectionString += $";Roles={settings.Role}";
+                hasImpersonation = true;
+            }
+            if (!string.IsNullOrWhiteSpace(settings.EffectiveUser))
+            {
+                queryConnectionString += $";EffectiveUserName={settings.EffectiveUser}";
+                hasImpersonation = true;
+            }
+
             var connMgr = new ConnectionManager(EventAggregator);
             var connEvent = new UIStubs.ConnectEvent()
             {
-                ConnectionString = settings.FullConnectionString,
+                ConnectionString = queryConnectionString,
                 ApplicationName = "DAX Studio Command Line",
                 DatabaseName = settings.Database,
                 PowerBIFileName = settings.PowerBIFileName ?? ""
@@ -144,7 +170,7 @@ namespace DaxStudio.CommandLine.Commands
             // approach the UI uses (BenchmarkViewModel subscribes to ServerTimingsEvent).
             var timingReady = new ManualResetEventSlim(false);
             EventAggregator.SubscribeOnPublishedThread(
-                new TraceCompletedHandler(() => timingReady.Set()));
+                new TraceCompletedHandler(serverTimes, () => timingReady.Set()));
 
             // Start trace
             if (!silent) AnsiConsole.MarkupLine("[yellow]Starting server trace...[/]");
@@ -167,6 +193,33 @@ namespace DaxStudio.CommandLine.Commands
                     AnsiConsole.MarkupLine("[yellow]Trace unavailable[/] — wall-clock timing only");
             }
 
+            // For cache clearing with RLS impersonation: use a separate admin
+            // connection without Roles/EffectiveUserName, since ClearCache
+            // requires server admin privileges that the impersonated role lacks.
+            ConnectionManager adminConnMgr = null;
+            if (hasImpersonation && settings.ColdRuns > 0)
+            {
+                try
+                {
+                    adminConnMgr = new ConnectionManager(new Caliburn.Micro.EventAggregator());
+                    var adminEvent = new UIStubs.ConnectEvent()
+                    {
+                        ConnectionString = baseConnectionString,
+                        ApplicationName = "DAX Studio Command Line (admin)",
+                        DatabaseName = settings.Database,
+                        PowerBIFileName = settings.PowerBIFileName ?? ""
+                    };
+                    adminConnMgr.Connect(adminEvent);
+                    adminConnMgr.SelectedModel = adminConnMgr.Database.Models.BaseModel;
+                    if (!silent) AnsiConsole.MarkupLine("[dim]Admin connection for cache clear established[/]");
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning("Could not create admin connection for cache clear: {message}", ex.Message);
+                    adminConnMgr = null;
+                }
+            }
+
             // Run benchmark
             int totalRuns = settings.ColdRuns + settings.WarmRuns;
             var details = new List<BenchmarkResult>();
@@ -177,7 +230,11 @@ namespace DaxStudio.CommandLine.Commands
                 if (cancellationToken.IsCancellationRequested) break;
                 sequence++;
 
-                try { connMgr.Database.ClearCache(); }
+                try
+                {
+                    var clearConn = adminConnMgr ?? connMgr;
+                    clearConn.Database.ClearCache();
+                }
                 catch (Exception ex) { Log.Warning("Cache clear failed: {message}", ex.Message); }
 
                 timingReady.Reset();
@@ -210,6 +267,7 @@ namespace DaxStudio.CommandLine.Commands
             // Stop trace and close
             try { await serverTimes.StopTraceAsync(); } catch { }
             connMgr.Close();
+            adminConnMgr?.Close();
 
             if (details.Count == 0)
             {
@@ -241,7 +299,10 @@ namespace DaxStudio.CommandLine.Commands
             {
                 using (var reader = connMgr.ExecuteReader(daxQuery, new List<AdomdParameter>()))
                 {
-                    while (reader.Read()) { rowCount++; }
+                    do
+                    {
+                        while (reader.Read()) { rowCount++; }
+                    } while (reader.NextResult());
                 }
             }
             catch (Exception ex)
@@ -362,29 +423,49 @@ namespace DaxStudio.CommandLine.Commands
                 "TotalCpu_ms,VertipaqCacheMatches,RowCount,Error");
 
             foreach (var r in details)
-                sb.AppendLine(string.Format(CultureInfo.InvariantCulture,
-                    "{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}",
-                    r.Sequence, r.CacheType, r.TotalDurationMs,
-                    r.FormulaEngineDurationMs, r.StorageEngineDurationMs,
-                    r.StorageEngineQueryCount, r.StorageEngineCpuMs,
-                    r.TotalCpuMs, r.VertipaqCacheMatches,
-                    r.RowCount, r.Error ?? ""));
+                sb.AppendLine(string.Join(",", new[]
+                {
+                    Csv(r.Sequence.ToString(CultureInfo.InvariantCulture)),
+                    Csv(r.CacheType),
+                    Csv(r.TotalDurationMs.ToString(CultureInfo.InvariantCulture)),
+                    Csv(r.FormulaEngineDurationMs.ToString(CultureInfo.InvariantCulture)),
+                    Csv(r.StorageEngineDurationMs.ToString(CultureInfo.InvariantCulture)),
+                    Csv(r.StorageEngineQueryCount.ToString(CultureInfo.InvariantCulture)),
+                    Csv(r.StorageEngineCpuMs.ToString(CultureInfo.InvariantCulture)),
+                    Csv(r.TotalCpuMs.ToString(CultureInfo.InvariantCulture)),
+                    Csv(r.VertipaqCacheMatches.ToString(CultureInfo.InvariantCulture)),
+                    Csv(r.RowCount.ToString(CultureInfo.InvariantCulture)),
+                    Csv(r.Error ?? string.Empty)
+                }));
 
             sb.AppendLine().AppendLine("# Summary");
             sb.AppendLine("Cache,Statistic,TotalDuration_ms,FormulaEngineDuration_ms," +
                 "StorageEngineDuration_ms,StorageEngineQueryCount,VertipaqCacheMatches,RowCount");
 
             foreach (var r in summary)
-                sb.AppendLine(string.Format(CultureInfo.InvariantCulture,
-                    "{0},{1},{2:F1},{3:F1},{4:F1},{5:F1},{6:F1},{7:F1}",
-                    r.CacheType, r.Statistic, r.TotalDurationMs,
-                    r.FormulaEngineDurationMs, r.StorageEngineDurationMs,
-                    r.StorageEngineQueryCount, r.VertipaqCacheMatches, r.RowCount));
+                sb.AppendLine(string.Join(",", new[]
+                {
+                    Csv(r.CacheType),
+                    Csv(r.Statistic),
+                    Csv(r.TotalDurationMs.ToString("F1", CultureInfo.InvariantCulture)),
+                    Csv(r.FormulaEngineDurationMs.ToString("F1", CultureInfo.InvariantCulture)),
+                    Csv(r.StorageEngineDurationMs.ToString("F1", CultureInfo.InvariantCulture)),
+                    Csv(r.StorageEngineQueryCount.ToString("F1", CultureInfo.InvariantCulture)),
+                    Csv(r.VertipaqCacheMatches.ToString("F1", CultureInfo.InvariantCulture)),
+                    Csv(r.RowCount.ToString("F1", CultureInfo.InvariantCulture))
+                }));
 
             var dir = Path.GetDirectoryName(outputFile);
             if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
                 Directory.CreateDirectory(dir);
             System.IO.File.WriteAllText(outputFile, sb.ToString(), Encoding.UTF8);
+        }
+
+        private static string Csv(string value)
+        {
+            if (value == null) return string.Empty;
+            if (value.IndexOfAny(new[] { ',', '"', '\r', '\n' }) < 0) return value;
+            return "\"" + value.Replace("\"", "\"\"") + "\"";
         }
 
         #endregion
@@ -428,10 +509,16 @@ namespace DaxStudio.CommandLine.Commands
         /// </summary>
         private class TraceCompletedHandler : IHandle<UI.Events.QueryTraceCompletedEvent>
         {
+            private readonly ITraceWatcher _traceWatcher;
             private readonly System.Action _callback;
-            public TraceCompletedHandler(System.Action callback) { _callback = callback; }
+            public TraceCompletedHandler(ITraceWatcher traceWatcher, System.Action callback)
+            {
+                _traceWatcher = traceWatcher;
+                _callback = callback;
+            }
             public Task HandleAsync(UI.Events.QueryTraceCompletedEvent message, CancellationToken cancellationToken)
             {
+                if (!ReferenceEquals(message.Trace, _traceWatcher)) return Task.CompletedTask;
                 _callback();
                 return Task.CompletedTask;
             }

--- a/src/DaxStudio.CommandLine/Commands/BenchmarkCommand.cs
+++ b/src/DaxStudio.CommandLine/Commands/BenchmarkCommand.cs
@@ -1,0 +1,440 @@
+using Caliburn.Micro;
+using DaxStudio.CommandLine.UIStubs;
+using DaxStudio.CommandLine.ViewModel;
+using DaxStudio.Interfaces;
+using DaxStudio.QueryTrace;
+using DaxStudio.QueryTrace.Interfaces;
+using DaxStudio.UI.Events;
+using DaxStudio.UI.Model;
+using DaxStudio.UI.ViewModels;
+using Microsoft.AnalysisServices.AdomdClient;
+using Serilog;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DaxStudio.CommandLine.Commands
+{
+    internal class BenchmarkCommand : AsyncCommand<BenchmarkCommand.Settings>
+    {
+        internal class Settings : CommandSettingsFileBase
+        {
+            [CommandOption("-f|--file <file>")]
+            [Description("A text file containing a DAX query to be executed")]
+            public string File { get; set; }
+
+            [CommandOption("-q|--query <query>")]
+            [Description("A DAX query to be executed")]
+            public string Query { get; set; }
+
+            [CommandOption("--cold <cold>")]
+            [Description("Number of cold cache (cache cleared) iterations")]
+            [DefaultValue(5)]
+            public int ColdRuns { get; set; }
+
+            [CommandOption("--warm <warm>")]
+            [Description("Number of warm cache iterations")]
+            [DefaultValue(5)]
+            public int WarmRuns { get; set; }
+
+            [CommandOption("--silent")]
+            [Description("Suppress console output (only write CSV)")]
+            [DefaultValue(false)]
+            public bool Silent { get; set; }
+        }
+
+        public IEventAggregator EventAggregator { get; }
+        public IGlobalOptions Options { get; }
+
+        public BenchmarkCommand(IEventAggregator eventAggregator, IGlobalOptions options)
+        {
+            EventAggregator = eventAggregator;
+            Options = options;
+        }
+
+        public override ValidationResult Validate(CommandContext context, Settings settings)
+        {
+            if (string.IsNullOrWhiteSpace(settings.OutputFile))
+                return ValidationResult.Error("You must specify an output file path");
+            if (string.IsNullOrWhiteSpace(settings.File) && string.IsNullOrWhiteSpace(settings.Query))
+                return ValidationResult.Error("You must specify either a --file or --query option");
+            if (!string.IsNullOrWhiteSpace(settings.File) && !string.IsNullOrWhiteSpace(settings.Query))
+                return ValidationResult.Error("You cannot specify both --file and --query");
+            if (settings.ColdRuns < 0)
+                return ValidationResult.Error("--cold must be >= 0");
+            if (settings.WarmRuns < 0)
+                return ValidationResult.Error("--warm must be >= 0");
+            if (settings.ColdRuns == 0 && settings.WarmRuns == 0)
+                return ValidationResult.Error("You must run at least one cold or warm iteration");
+            return base.Validate(context, settings);
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+        {
+            Log.Information("Starting Benchmark command");
+            bool silent = settings.Silent;
+
+            // Install a SynchronizationContext so that Caliburn.Micro's
+            // PublishOnUIThreadAsync works in the CLI (no WPF dispatcher).
+            // Without this, ServerTimingsEvent may not be delivered to our handler.
+            if (SynchronizationContext.Current == null)
+                SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+
+            // Read query
+            string daxQuery = settings.Query;
+            if (!string.IsNullOrWhiteSpace(settings.File))
+            {
+                if (!System.IO.File.Exists(settings.File))
+                {
+                    if (!silent) AnsiConsole.MarkupLine($"[red]Error:[/] Query file not found: {Markup.Escape(settings.File)}");
+                    return 1;
+                }
+                daxQuery = System.IO.File.ReadAllText(settings.File);
+            }
+
+            if (string.IsNullOrWhiteSpace(daxQuery))
+            {
+                if (!silent) AnsiConsole.MarkupLine("[red]Error:[/] Query is empty");
+                return 1;
+            }
+
+            // Connect — same pattern as CustomTraceCommand (lines 98-110)
+            var connMgr = new ConnectionManager(EventAggregator);
+            var connEvent = new UIStubs.ConnectEvent()
+            {
+                ConnectionString = settings.FullConnectionString,
+                ApplicationName = "DAX Studio Command Line",
+                DatabaseName = settings.Database,
+                PowerBIFileName = settings.PowerBIFileName ?? ""
+            };
+
+            try
+            {
+                if (!silent) AnsiConsole.MarkupLine("[yellow]Connecting...[/]");
+                connMgr.Connect(connEvent);
+                connMgr.SelectedModel = connMgr.Database.Models.BaseModel;
+                connMgr.SelectedModelName = connMgr.SelectedModel.Name;
+                if (!silent) AnsiConsole.MarkupLine($"[green]Connected[/] to [bold]{Markup.Escape(connMgr.ServerName)}[/]");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Connection failed");
+                if (!silent) AnsiConsole.MarkupLine($"[red]Connection failed:[/] {Markup.Escape(ex.Message)}");
+                return 1;
+            }
+
+            // Set up trace watcher — same pattern as CustomTraceCommand (lines 112-120)
+            var metadataPane = new CmdLineMetadataPane();
+            var doc = new CmdLineDocument(connMgr, metadataPane);
+
+            var serverTimes = new CmdServerTimesViewModel(
+                EventAggregator, new ServerTimingDetailsViewModel(), Options, null);
+            serverTimes.Document = doc;
+
+            // Subscribe to QueryTraceCompletedEvent — fired by ProcessAllEvents()
+            // after ProcessResults() completes. This is the same event-driven
+            // approach the UI uses (BenchmarkViewModel subscribes to ServerTimingsEvent).
+            var timingReady = new ManualResetEventSlim(false);
+            EventAggregator.SubscribeOnPublishedThread(
+                new TraceCompletedHandler(() => timingReady.Set()));
+
+            // Start trace
+            if (!silent) AnsiConsole.MarkupLine("[yellow]Starting server trace...[/]");
+            serverTimes.IsChecked = true;
+
+            // Wait for trace to become active
+            int waitMs = 0;
+            while (serverTimes.TraceStatus != QueryTraceStatus.Started && waitMs < 30000)
+            {
+                Thread.Sleep(500);
+                waitMs += 500;
+            }
+
+            bool traceActive = serverTimes.TraceStatus == QueryTraceStatus.Started;
+            if (!silent)
+            {
+                if (traceActive)
+                    AnsiConsole.MarkupLine("[green]Server trace active[/] — capturing FE/SE timings");
+                else
+                    AnsiConsole.MarkupLine("[yellow]Trace unavailable[/] — wall-clock timing only");
+            }
+
+            // Run benchmark
+            int totalRuns = settings.ColdRuns + settings.WarmRuns;
+            var details = new List<BenchmarkResult>();
+            int sequence = 0;
+
+            for (int i = 0; i < settings.ColdRuns; i++)
+            {
+                if (cancellationToken.IsCancellationRequested) break;
+                sequence++;
+
+                try { connMgr.Database.ClearCache(); }
+                catch (Exception ex) { Log.Warning("Cache clear failed: {message}", ex.Message); }
+
+                timingReady.Reset();
+                var r = ExecuteTimedQuery(connMgr, daxQuery, sequence, "Cold",
+                    traceActive, serverTimes, timingReady);
+                details.Add(r);
+
+                if (!silent)
+                    AnsiConsole.MarkupLine($"  Cold {i + 1}/{settings.ColdRuns}: [bold]{r.TotalDurationMs}ms[/] " +
+                        $"(FE={r.FormulaEngineDurationMs} SE={r.StorageEngineDurationMs} " +
+                        $"SEq={r.StorageEngineQueryCount} rows={r.RowCount})");
+            }
+
+            for (int i = 0; i < settings.WarmRuns; i++)
+            {
+                if (cancellationToken.IsCancellationRequested) break;
+                sequence++;
+
+                timingReady.Reset();
+                var r = ExecuteTimedQuery(connMgr, daxQuery, sequence, "Warm",
+                    traceActive, serverTimes, timingReady);
+                details.Add(r);
+
+                if (!silent)
+                    AnsiConsole.MarkupLine($"  Warm {i + 1}/{settings.WarmRuns}: [bold]{r.TotalDurationMs}ms[/] " +
+                        $"(FE={r.FormulaEngineDurationMs} SE={r.StorageEngineDurationMs} " +
+                        $"SEq={r.StorageEngineQueryCount} rows={r.RowCount})");
+            }
+
+            // Stop trace and close
+            try { await serverTimes.StopTraceAsync(); } catch { }
+            connMgr.Close();
+
+            if (details.Count == 0)
+            {
+                if (!silent) AnsiConsole.MarkupLine("[yellow]No benchmark results collected[/]");
+                return 1;
+            }
+
+            var summary = CalculateSummary(details);
+            if (!silent) PrintSummaryTable(summary, traceActive);
+            WriteCsvOutput(settings.OutputFile, details, summary);
+            if (!silent) AnsiConsole.MarkupLine($"\n[green]Results written to:[/] {Markup.Escape(settings.OutputFile)}");
+
+            Log.Information("Finished Benchmark command");
+            return 0;
+        }
+
+        private static BenchmarkResult ExecuteTimedQuery(
+            ConnectionManager connMgr, string daxQuery, int sequence, string cacheType,
+            bool traceActive, CmdServerTimesViewModel serverTimes,
+            ManualResetEventSlim timingReady)
+        {
+            // Reset trace state so we get fresh timings for this run
+            if (traceActive) serverTimes.OnReset();
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            long rowCount = 0;
+
+            try
+            {
+                using (var reader = connMgr.ExecuteReader(daxQuery, new List<AdomdParameter>()))
+                {
+                    while (reader.Read()) { rowCount++; }
+                }
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                return new BenchmarkResult
+                {
+                    Sequence = sequence, CacheType = cacheType,
+                    TotalDurationMs = sw.ElapsedMilliseconds, Error = ex.Message
+                };
+            }
+            sw.Stop();
+
+            var result = new BenchmarkResult
+            {
+                Sequence = sequence, CacheType = cacheType,
+                TotalDurationMs = sw.ElapsedMilliseconds, RowCount = rowCount
+            };
+
+            // Wait for ProcessResults() to complete via the event-driven signal.
+            // QueryTraceCompletedEvent is published by ProcessAllEvents() after
+            // ProcessResults() finishes — same signal the UI uses.
+            if (traceActive)
+            {
+                int timeoutMs = Math.Max(15000, (int)sw.ElapsedMilliseconds * 3);
+                if (timingReady.Wait(timeoutMs))
+                {
+                    result.TotalDurationMs = serverTimes.TotalDuration;
+                    result.FormulaEngineDurationMs = serverTimes.FormulaEngineDuration;
+                    result.StorageEngineDurationMs = serverTimes.StorageEngineDuration;
+                    result.StorageEngineQueryCount = serverTimes.StorageEngineQueryCount;
+                    result.StorageEngineCpuMs = serverTimes.StorageEngineCpu;
+                    result.TotalCpuMs = serverTimes.TotalCpuDuration;
+                    result.VertipaqCacheMatches = serverTimes.VertipaqCacheMatches;
+                }
+            }
+
+            return result;
+        }
+
+        #region Summary & Output
+
+        private static List<BenchmarkSummaryRow> CalculateSummary(List<BenchmarkResult> details)
+        {
+            var summary = new List<BenchmarkSummaryRow>();
+            foreach (var group in details.Where(d => d.Error == null).GroupBy(d => d.CacheType))
+            {
+                var rows = group.ToArray();
+                AddStat(summary, group.Key, "Average", rows, Enumerable.Average);
+                AddStat(summary, group.Key, "StdDev", rows, StdDev);
+                AddStat(summary, group.Key, "Min", rows, Enumerable.Min);
+                AddStat(summary, group.Key, "Max", rows, Enumerable.Max);
+            }
+            return summary;
+        }
+
+        private static void AddStat(List<BenchmarkSummaryRow> summary, string cache, string stat,
+            BenchmarkResult[] rows, Func<IEnumerable<double>, double> agg)
+        {
+            summary.Add(new BenchmarkSummaryRow
+            {
+                CacheType = cache, Statistic = stat,
+                TotalDurationMs = agg(rows.Select(r => (double)r.TotalDurationMs)),
+                FormulaEngineDurationMs = agg(rows.Select(r => (double)r.FormulaEngineDurationMs)),
+                StorageEngineDurationMs = agg(rows.Select(r => (double)r.StorageEngineDurationMs)),
+                StorageEngineQueryCount = agg(rows.Select(r => (double)r.StorageEngineQueryCount)),
+                VertipaqCacheMatches = agg(rows.Select(r => (double)r.VertipaqCacheMatches)),
+                RowCount = agg(rows.Select(r => (double)r.RowCount))
+            });
+        }
+
+        private static double StdDev(IEnumerable<double> values)
+        {
+            var arr = values.ToArray();
+            if (arr.Length <= 1) return 0;
+            double avg = arr.Average();
+            return Math.Sqrt(arr.Select(v => Math.Pow(v - avg, 2)).Sum() / (arr.Length - 1));
+        }
+
+        private static void PrintSummaryTable(List<BenchmarkSummaryRow> summary, bool hasTrace)
+        {
+            AnsiConsole.WriteLine();
+            var table = new Table().Title("[bold]Benchmark Summary[/]");
+            table.AddColumn("Cache");
+            table.AddColumn("Statistic");
+            table.AddColumn(new TableColumn("Total (ms)").RightAligned());
+            if (hasTrace)
+            {
+                table.AddColumn(new TableColumn("FE (ms)").RightAligned());
+                table.AddColumn(new TableColumn("SE (ms)").RightAligned());
+                table.AddColumn(new TableColumn("SE Queries").RightAligned());
+                table.AddColumn(new TableColumn("SE Cache").RightAligned());
+            }
+            table.AddColumn(new TableColumn("Rows").RightAligned());
+
+            foreach (var row in summary)
+            {
+                if (hasTrace)
+                    table.AddRow(row.CacheType, row.Statistic,
+                        N(row.TotalDurationMs), N(row.FormulaEngineDurationMs),
+                        N(row.StorageEngineDurationMs), N(row.StorageEngineQueryCount),
+                        N(row.VertipaqCacheMatches), N(row.RowCount));
+                else
+                    table.AddRow(row.CacheType, row.Statistic,
+                        N(row.TotalDurationMs), N(row.RowCount));
+            }
+            AnsiConsole.Write(table);
+        }
+
+        private static string N(double v) => v.ToString("N0", CultureInfo.InvariantCulture);
+
+        private static void WriteCsvOutput(string outputFile, List<BenchmarkResult> details,
+            List<BenchmarkSummaryRow> summary)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("Sequence,Cache,TotalDuration_ms,FormulaEngineDuration_ms," +
+                "StorageEngineDuration_ms,StorageEngineQueryCount,StorageEngineCpu_ms," +
+                "TotalCpu_ms,VertipaqCacheMatches,RowCount,Error");
+
+            foreach (var r in details)
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture,
+                    "{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}",
+                    r.Sequence, r.CacheType, r.TotalDurationMs,
+                    r.FormulaEngineDurationMs, r.StorageEngineDurationMs,
+                    r.StorageEngineQueryCount, r.StorageEngineCpuMs,
+                    r.TotalCpuMs, r.VertipaqCacheMatches,
+                    r.RowCount, r.Error ?? ""));
+
+            sb.AppendLine().AppendLine("# Summary");
+            sb.AppendLine("Cache,Statistic,TotalDuration_ms,FormulaEngineDuration_ms," +
+                "StorageEngineDuration_ms,StorageEngineQueryCount,VertipaqCacheMatches,RowCount");
+
+            foreach (var r in summary)
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture,
+                    "{0},{1},{2:F1},{3:F1},{4:F1},{5:F1},{6:F1},{7:F1}",
+                    r.CacheType, r.Statistic, r.TotalDurationMs,
+                    r.FormulaEngineDurationMs, r.StorageEngineDurationMs,
+                    r.StorageEngineQueryCount, r.VertipaqCacheMatches, r.RowCount));
+
+            var dir = Path.GetDirectoryName(outputFile);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            System.IO.File.WriteAllText(outputFile, sb.ToString(), Encoding.UTF8);
+        }
+
+        #endregion
+
+        #region Data Classes
+
+        internal class BenchmarkResult
+        {
+            public int Sequence { get; set; }
+            public string CacheType { get; set; }
+            public long TotalDurationMs { get; set; }
+            public long FormulaEngineDurationMs { get; set; }
+            public long StorageEngineDurationMs { get; set; }
+            public long StorageEngineQueryCount { get; set; }
+            public long StorageEngineCpuMs { get; set; }
+            public long TotalCpuMs { get; set; }
+            public int VertipaqCacheMatches { get; set; }
+            public long RowCount { get; set; }
+            public string Error { get; set; }
+        }
+
+        internal class BenchmarkSummaryRow
+        {
+            public string CacheType { get; set; }
+            public string Statistic { get; set; }
+            public double TotalDurationMs { get; set; }
+            public double FormulaEngineDurationMs { get; set; }
+            public double StorageEngineDurationMs { get; set; }
+            public double StorageEngineQueryCount { get; set; }
+            public double VertipaqCacheMatches { get; set; }
+            public double RowCount { get; set; }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Handles QueryTraceCompletedEvent from the event aggregator.
+        /// Fired by TraceWatcherBaseViewModel.ProcessAllEvents() after
+        /// ProcessResults() completes — signals that IServerTimes properties
+        /// on ServerTimesViewModel are now populated with fresh data.
+        /// </summary>
+        private class TraceCompletedHandler : IHandle<UI.Events.QueryTraceCompletedEvent>
+        {
+            private readonly System.Action _callback;
+            public TraceCompletedHandler(System.Action callback) { _callback = callback; }
+            public Task HandleAsync(UI.Events.QueryTraceCompletedEvent message, CancellationToken cancellationToken)
+            {
+                _callback();
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/DaxStudio.CommandLine/DaxStudio.CommandLine.csproj
+++ b/src/DaxStudio.CommandLine/DaxStudio.CommandLine.csproj
@@ -79,6 +79,7 @@
   <ItemGroup>
     <Compile Include="Attributes\DirectLakeModeDescriptionAttribute.cs" />
     <Compile Include="Commands\AccessTokenCommand.cs" />
+    <Compile Include="Commands\BenchmarkCommand.cs" />
     <Compile Include="Commands\CommandSettingsBase.cs" />
     <Compile Include="Commands\ExportParquetCommand.cs" />
     <Compile Include="Helpers\AccessTokenHelper.cs" />
@@ -112,6 +113,7 @@
     <Compile Include="UIStubs\QueryRunner.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="ViewModel\CmdCustomTraceViewModel.cs" />
+    <Compile Include="ViewModel\CmdServerTimesViewModel.cs" />
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
@@ -134,6 +136,10 @@
     <ProjectReference Include="..\DaxStudio.Interfaces\DaxStudio.Interfaces.csproj">
       <Project>{9cdccc97-ca3b-4bdf-b062-da0266387b76}</Project>
       <Name>DaxStudio.Interfaces</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\DaxStudio.QueryTrace\DaxStudio.QueryTrace.csproj">
+      <Project>{A7912ABB-E3AD-45C4-A8A7-183828DB300E}</Project>
+      <Name>DaxStudio.QueryTrace</Name>
     </ProjectReference>
     <ProjectReference Include="..\DaxStudio.UI\DaxStudio.UI.csproj">
       <Project>{5efeff14-3052-4dc1-b020-8e259062b899}</Project>

--- a/src/DaxStudio.CommandLine/Program.cs
+++ b/src/DaxStudio.CommandLine/Program.cs
@@ -169,6 +169,10 @@ namespace DaxStudio.CommandLine
                             .WithDescription("Returns an access token that can be used to run other commands without repeated authentication prompts")
                             .WithExample(new[] { "accesstoken", "-s", "asazure://australiasoutheast.asazure.windows.net/myserver", "-d", "\"Adventure Works\"" })
                             .WithExample(new[] { "accesstoken", "-c", "\"Data Source=asazure://australiasoutheast.asazure.windows.net/myserver;Initial Catalog=Adventure Works\"" });
+
+            config.AddCommand<BenchmarkCommand>("benchmark")
+                .WithDescription("Runs a DAX query benchmark with cold and warm cache timings")
+                .WithExample(new[] { "benchmark", "c:\\temp\\results.csv", "-s", "localhost\\tabular", "-d", "\"Adventure Works\"", "-f", "query.dax", "--cold", "5", "--warm", "5" });
 #if DEBUG
                 // Custom Trace
                 config.AddCommand<CustomTraceCommand>("customtrace")

--- a/src/DaxStudio.CommandLine/ViewModel/CmdServerTimesViewModel.cs
+++ b/src/DaxStudio.CommandLine/ViewModel/CmdServerTimesViewModel.cs
@@ -1,0 +1,21 @@
+using Caliburn.Micro;
+using DaxStudio.Interfaces;
+using DaxStudio.UI.ViewModels;
+
+namespace DaxStudio.CommandLine.ViewModel
+{
+    /// <summary>
+    /// CLI-compatible subclass of ServerTimesViewModel.
+    /// Follows the CmdCustomTraceViewModel pattern — all timing logic
+    /// (FE/SE gap analysis, ProcessResults) stays in the base class.
+    /// </summary>
+    internal class CmdServerTimesViewModel : ServerTimesViewModel
+    {
+        public CmdServerTimesViewModel(IEventAggregator eventAggregator,
+            ServerTimingDetailsViewModel serverTimingDetails,
+            IGlobalOptions options, IWindowManager windowManager)
+            : base(eventAggregator, serverTimingDetails, options, windowManager)
+        {
+        }
+    }
+}

--- a/tests/DaxStudio.CommandLine.Tests/BenchmarkCommandTests.cs
+++ b/tests/DaxStudio.CommandLine.Tests/BenchmarkCommandTests.cs
@@ -6,6 +6,8 @@ namespace DaxStudio.CommandLine.Tests
     [TestClass]
     public class BenchmarkCommandTests
     {
+    private static BenchmarkCommand CreateCommand() => new BenchmarkCommand(null, null);
+
         // Tests validate the Settings class directly (same pattern as
         // CommandLineParameterTests). BenchmarkCommand constructor requires
         // DI-injected IEventAggregator/IGlobalOptions, so we test Settings.Validate()
@@ -69,6 +71,80 @@ namespace DaxStudio.CommandLine.Tests
             var result = settings.Validate();
             Assert.IsFalse(result.Successful);
             Assert.AreEqual("You must specify a <server> when using the <database> parameter", result.Message);
+        }
+
+        [TestMethod]
+        public void Benchmark_validate_requires_file_or_query()
+        {
+            var settings = new BenchmarkCommand.Settings();
+            settings.Server = "localhost";
+            settings.Database = "Adventure Works";
+            settings.OutputFile = "c:\\temp\\results.csv";
+
+            var result = CreateCommand().Validate(null, settings);
+            Assert.IsFalse(result.Successful);
+            Assert.AreEqual("You must specify either a --file or --query option", result.Message);
+        }
+
+        [TestMethod]
+        public void Benchmark_validate_rejects_file_and_query_together()
+        {
+            var settings = new BenchmarkCommand.Settings();
+            settings.Server = "localhost";
+            settings.Database = "Adventure Works";
+            settings.OutputFile = "c:\\temp\\results.csv";
+            settings.File = "query.dax";
+            settings.Query = "EVALUATE ROW(\"x\", 1)";
+
+            var result = CreateCommand().Validate(null, settings);
+            Assert.IsFalse(result.Successful);
+            Assert.AreEqual("You cannot specify both --file and --query", result.Message);
+        }
+
+        [TestMethod]
+        public void Benchmark_validate_rejects_both_run_counts_zero()
+        {
+            var settings = new BenchmarkCommand.Settings();
+            settings.Server = "localhost";
+            settings.Database = "Adventure Works";
+            settings.OutputFile = "c:\\temp\\results.csv";
+            settings.Query = "EVALUATE ROW(\"x\", 1)";
+            settings.ColdRuns = 0;
+            settings.WarmRuns = 0;
+
+            var result = CreateCommand().Validate(null, settings);
+            Assert.IsFalse(result.Successful);
+            Assert.AreEqual("You must run at least one cold or warm iteration", result.Message);
+        }
+
+        [TestMethod]
+        public void Benchmark_validate_rejects_negative_cold()
+        {
+            var settings = new BenchmarkCommand.Settings();
+            settings.Server = "localhost";
+            settings.Database = "Adventure Works";
+            settings.OutputFile = "c:\\temp\\results.csv";
+            settings.Query = "EVALUATE ROW(\"x\", 1)";
+            settings.ColdRuns = -1;
+
+            var result = CreateCommand().Validate(null, settings);
+            Assert.IsFalse(result.Successful);
+            Assert.AreEqual("--cold must be >= 0", result.Message);
+        }
+
+        [TestMethod]
+        public void Benchmark_validate_rejects_negative_warm()
+        {
+            var settings = new BenchmarkCommand.Settings();
+            settings.Server = "localhost";
+            settings.Database = "Adventure Works";
+            settings.OutputFile = "c:\\temp\\results.csv";
+            settings.Query = "EVALUATE ROW(\"x\", 1)";
+            settings.WarmRuns = -1;
+
+            var result = CreateCommand().Validate(null, settings);
+            Assert.IsFalse(result.Successful);
+            Assert.AreEqual("--warm must be >= 0", result.Message);
         }
     }
 }

--- a/tests/DaxStudio.CommandLine.Tests/BenchmarkCommandTests.cs
+++ b/tests/DaxStudio.CommandLine.Tests/BenchmarkCommandTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DaxStudio.CommandLine.Commands;
+
+namespace DaxStudio.CommandLine.Tests
+{
+    [TestClass]
+    public class BenchmarkCommandTests
+    {
+        // Tests validate the Settings class directly (same pattern as
+        // CommandLineParameterTests). BenchmarkCommand constructor requires
+        // DI-injected IEventAggregator/IGlobalOptions, so we test Settings.Validate()
+        // which tests the connection string validation inherited from CommandSettingsRawBase.
+
+        [TestMethod]
+        public void Benchmark_settings_with_server_database_should_succeed()
+        {
+            var settings = new BenchmarkCommand.Settings();
+            settings.Server = "localhost";
+            settings.Database = "Adventure Works";
+            settings.OutputFile = "c:\\temp\\results.csv";
+
+            var result = settings.Validate();
+            Assert.IsTrue(result.Successful, result.Message);
+        }
+
+        [TestMethod]
+        public void Benchmark_settings_with_connectionstring_should_succeed()
+        {
+            var settings = new BenchmarkCommand.Settings();
+            settings.ConnectionString = "Data Source=localhost;Initial Catalog=Adventure Works";
+            settings.OutputFile = "c:\\temp\\results.csv";
+
+            var result = settings.Validate();
+            Assert.IsTrue(result.Successful, result.Message);
+        }
+
+        [TestMethod]
+        public void Benchmark_settings_only_servername_should_fail()
+        {
+            var settings = new BenchmarkCommand.Settings();
+            settings.Server = "localhost";
+            settings.OutputFile = "c:\\temp\\results.csv";
+
+            var result = settings.Validate();
+            Assert.IsFalse(result.Successful);
+            Assert.AreEqual("You must specify a <database> when using the <server> parameter and not connecting to a .pbix/.pbip file", result.Message);
+        }
+
+        [TestMethod]
+        public void Benchmark_settings_server_with_connectionstring_should_fail()
+        {
+            var settings = new BenchmarkCommand.Settings();
+            settings.Server = "localhost";
+            settings.ConnectionString = "Data Source=localhost";
+            settings.OutputFile = "c:\\temp\\results.csv";
+
+            var result = settings.Validate();
+            Assert.IsFalse(result.Successful);
+            Assert.AreEqual("You cannot specify a <Server> or <Database> when passing a <ConnectionString>", result.Message);
+        }
+
+        [TestMethod]
+        public void Benchmark_settings_only_database_should_fail()
+        {
+            var settings = new BenchmarkCommand.Settings();
+            settings.Database = "Adventure Works";
+            settings.OutputFile = "c:\\temp\\results.csv";
+
+            var result = settings.Validate();
+            Assert.IsFalse(result.Successful);
+            Assert.AreEqual("You must specify a <server> when using the <database> parameter", result.Message);
+        }
+    }
+}

--- a/tests/DaxStudio.CommandLine.Tests/DaxStudio.CommandLine.Tests.csproj
+++ b/tests/DaxStudio.CommandLine.Tests/DaxStudio.CommandLine.Tests.csproj
@@ -151,6 +151,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BenchmarkCommandTests.cs" />
     <Compile Include="CommandLineParameterTests.cs" />
     <Compile Include="ListTypeConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Closes #1436

### Summary

Adds a `dscmd benchmark` command that runs a DAX query with configurable cold/warm cache iterations and captures detailed FE/SE server timings — the same timing breakdown shown by Run Benchmark in the desktop UI.

### Architecture

This follows the established `CustomTraceCommand` / `CmdCustomTraceViewModel` pattern:

- **`CmdServerTimesViewModel`** (21 lines) — CLI subclass of `ServerTimesViewModel`. Passes through to the base class with zero overridden timing logic. All FE/SE computation (including the parallel SE gap-analysis algorithm in `ProcessResults()`) stays in the existing, tested `ServerTimesViewModel`.

- **`BenchmarkCommand`** — `AsyncCommand<Settings>` that follows the `CustomTraceCommand` connection/trace wiring pattern:
  1. Creates `ConnectionManager` + `CmdLineDocument` (same as `CustomTraceCommand` lines 98-112)
  2. Sets `SelectedModel` on the connection (required for Fabric trace support)
  3. Wires `CmdServerTimesViewModel.Document` then sets `IsChecked = true` to start the trace
  4. Subscribes to `QueryTraceCompletedEvent` via `IEventAggregator` to detect `ProcessResults()` completion
  5. Reads `IServerTimes` properties directly from the `ServerTimesViewModel` instance
  6. Outputs detail+summary CSV and Spectre.Console table

### Connection Management for RLS Testing

When `--role` or `--effective-user` is specified, the command manages two connections:

- **Query connection** — includes `Roles=` and/or `EffectiveUserName=` in the connection string for RLS-impersonated query execution
- **Admin connection** — uses the base connection string (no impersonation) for `Database.ClearCache()` XMLA commands, since cache clearing requires server admin privileges that the impersonated role may lack

Without impersonation, a single connection handles both queries and cache clearing.

### Why `QueryTraceCompletedEvent` instead of `ServerTimingsEvent`?

`ServerTimingsEvent` is published via `PublishOnUIThreadAsync`, which requires a WPF dispatcher to deliver reliably. In the CLI (no UI thread), delivery is inconsistent. `QueryTraceCompletedEvent` fires from `ProcessAllEvents()` on the trace callback thread and delivers reliably via `SubscribeOnPublishedThread`. The `IServerTimes` property values are read directly from the `ServerTimesViewModel` instance after `ProcessAllEvents()` signals completion — same data, reliable delivery.

### Features

- `--cold` / `--warm` iteration counts (default 5 each)
- `--silent` flag for scripted/CI usage (suppresses console output)
- `--role` for RLS role testing (adds `Roles=` to query connection string)
- `--effective-user` for user impersonation (adds `EffectiveUserName=` to query connection string)
- `-f` / `-q` for query file or inline query
- `Database.ClearCache()` XMLA command for cold cache runs (uses separate admin connection when `--role`/`--effective-user` is active to avoid permission issues)
- CSV output: detail rows + summary statistics (Average, StdDev, Min, Max)
- CSV-safe escaping for all output fields (handles commas/quotes/newlines in error messages)
- Console: Spectre.Console summary table with FE/SE/SE Queries/SE Cache/Rows columns
- Graceful fallback to wall-clock timing if trace unavailable
- Row count includes all result sets (`reader.NextResult()`)

### Output Columns

Same metrics as the desktop Run Benchmark feature:

| Column | Source |
|---|---|
| TotalDuration_ms | `IServerTimes.TotalDuration` |
| FormulaEngineDuration_ms | `IServerTimes.FormulaEngineDuration` |
| StorageEngineDuration_ms | `IServerTimes.StorageEngineDuration` |
| StorageEngineQueryCount | `IServerTimes.StorageEngineQueryCount` |
| StorageEngineCpu_ms | `IServerTimes.StorageEngineCpu` |
| TotalCpu_ms | `IServerTimes.TotalCpuDuration` |
| VertipaqCacheMatches | `IServerTimes.VertipaqCacheMatches` |
| RowCount | Total rows across all result sets |

`TotalDuration_ms` uses server trace duration when trace is available; otherwise it falls back to client wall-clock duration.

### Testing

- Added benchmark-specific validation tests for `--file/--query` exclusivity and cold/warm argument constraints
- **19/19 unit tests pass** (14 existing + 5 new Settings validation tests)
- **E2E tested** against Adventure Works DW 2020 and a 580M-row production model in Fabric
- FE/SE breakdown verified: cold runs show FE+SE activity, warm runs show SE cache hits
- RLS role impersonation verified: `--role "Test E T0"` with admin cache clear working
- Auth works seamlessly with Fabric XMLA endpoints (Entra ID interactive)

### Known Limitations

- `--effective-user` requires server admin permissions and is not supported on all Fabric XMLA endpoint configurations. Works on SSAS on-premises and Power BI Desktop.
- For sub-millisecond queries on Fabric, trace event delivery may lag behind query completion. The command uses a scaled timeout (min 10s, up to 3x query duration) to accommodate Fabric trace latency.

### Possible Future Enhancements

- Add a parameter to stamp queries with a comment like //Dax Studio Benchmark | < GUID > | Run <Cold 1>. This will allow retrieving Log Analytics Data for the specific queries.
- Make outputting to a file path optional

### Files Changed

| File | Change |
|---|---|
| `src/DaxStudio.CommandLine/Commands/BenchmarkCommand.cs` | New — CLI command |
| `src/DaxStudio.CommandLine/ViewModel/CmdServerTimesViewModel.cs` | New — 21-line CLI subclass |
| `src/DaxStudio.CommandLine/Program.cs` | Add command registration |
| `src/DaxStudio.CommandLine/DaxStudio.CommandLine.csproj` | Add compile includes + QueryTrace project reference |
| `tests/DaxStudio.CommandLine.Tests/BenchmarkCommandTests.cs` | New — 5 validation tests |
| `tests/DaxStudio.CommandLine.Tests/DaxStudio.CommandLine.Tests.csproj` | Add test include |

**Zero changes to existing UI code.** All FE/SE timing logic reused from `ServerTimesViewModel`.

### Usage

```
dscmd benchmark results.csv -s localhost\tabular -d "Adventure Works" -f query.dax --cold 5 --warm 5
dscmd benchmark results.csv -c "Data Source=powerbi://api.powerbi.com/v1.0/myorg/My Workspace;Initial Catalog=My Model" -f query.dax --cold 3 --warm 3 --silent
```

### Documentation

Companion PR for docs: [savoy9/DaxStudio-Docs#feature/cli-benchmark-docs-v2](https://github.com/DaxStudio/DaxStudio-Docs/pull/8)
