### PR TITLE
Update DaxFormatterProxy to use the new API endpoint

### DIFF
--- a/src/DaxStudio.UI/Model/DaxFormatter.cs
+++ b/src/DaxStudio.UI/Model/DaxFormatter.cs
@@ -96,8 +96,6 @@ namespace DaxStudio.UI.Model
             System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
         }
 
-        private static string redirectUrl;  // cache the redirected URL
-        private static string redirectHost;
         //public static async Task FormatQuery(DocumentViewModel doc, DAXEditor.DAXEditor editor)
         //{
         //    Log.Debug("{class} {method} {event}", "DaxFormatter", "FormatQuery", "Start");
@@ -227,14 +225,9 @@ namespace DaxStudio.UI.Model
 
                 
 
-                await PrimeConnectionAsync(uri, globalOptions,eventAggregator);
-
-                Uri originalUri = new Uri(uri);
-                string actualUrl = new UriBuilder(originalUri.Scheme, redirectHost, originalUri.Port, originalUri.PathAndQuery).ToString();
-
                 //var webRequestFactory = IoC.Get<WebRequestFactory>();
                 var webRequestFactory = await WebRequestFactory.CreateAsync( globalOptions, eventAggregator);
-                var wr = webRequestFactory.Create(new Uri(actualUrl));
+                var wr = webRequestFactory.Create(new Uri(uri));
 
                 wr.Timeout = globalOptions.DaxFormatterRequestTimeout.SecondsToMilliseconds();
                 wr.ContentType = "application/json";
@@ -274,66 +267,5 @@ namespace DaxStudio.UI.Model
             }
         }
 
-        public static async Task PrimeConnectionAsync(string uri, IGlobalOptions globalOptions, IEventAggregator eventAggregator)
-        {
-            
-            Log.Debug("{class} {method} {event}", "DaxFormatter", "PrimeConnectionAsync", "Start");
-            try
-            {
-                if (globalOptions.BlockExternalServices)
-                {
-                    Log.Debug(Common.Constants.LogMessageTemplate, nameof(DaxFormatterProxy), nameof(PrimeConnectionAsync), "Skipping Priming Connection to DaxFormatter.com as External Services are blocked in options");
-                    return;
-                }
-                
-                if (redirectHost == null)
-                {
-                    // www.daxformatter.com redirects request to another site.  HttpWebRequest does redirect with GET.  It fails, since the web service works only with POST
-                    // The following 2 requests are doing manual POST re-direct
-                    //var webRequestFactory = IoC.Get<WebRequestFactory>();
-                    WebRequestFactory webRequestFactory =
-                        await WebRequestFactory.CreateAsync(globalOptions, eventAggregator);
-                    var redirectRequest = webRequestFactory.Create(uri) as HttpWebRequest;
-
-                    redirectRequest.AllowAutoRedirect = false;
-                    redirectRequest.Timeout = globalOptions.DaxFormatterRequestTimeout.SecondsToMilliseconds();
-                    try
-                    {
-                        using (var netResponse = await redirectRequest.GetResponseAsync())
-                        {
-                            var redirectResponse = (HttpWebResponse) netResponse;
-                            redirectUrl = redirectResponse.Headers["Location"];
-                            var redirectUri = new Uri(redirectUrl);
-
-                            // set the shared redirectHost variable
-                            redirectHost = redirectUri.Host;
-                            Log.Debug("{class} {method} Redirected to: {redirectUrl}", "DaxFormatter",
-                                "CallDaxFormatterAsync", uri.ToString());
-                            System.Diagnostics.Debug.WriteLine("Host: " + redirectUri.Host);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error("{class} {method} {error}", "DaxFormatter", "PrimeConnectionAsync",
-                            $"Error getting redirect response: {ex.Message}");
-                    }
-                }
-            }
-            catch (Exception ex1)
-            {
-                Log.Error("{class} {method} {error}", "DaxFormatter", "PrimeConnectionAsync",
-                    $"Error getting redirect location: {ex1.Message}");
-                await eventAggregator.PublishOnUIThreadAsync(new OutputMessage(MessageType.Warning,
-                    $"An error occurred while checking the connection to daxformatter.com\n\t{ex1.Message}"));
-            }
-
-            Log.Debug("{class} {method} {event}", "DaxFormatter", "PrimeConnectionAsync", "End");
-
-        }
-        public static async Task PrimeConnectionAsync(IGlobalOptions globalOptions, IEventAggregator eventAggregator)
-        {
-            await PrimeConnectionAsync(WebRequestFactory.DaxTextFormatUri, globalOptions, eventAggregator);
-        }
-        
     }
 }

--- a/src/DaxStudio.UI/Utils/WebRequestFactory.cs
+++ b/src/DaxStudio.UI/Utils/WebRequestFactory.cs
@@ -32,7 +32,7 @@ namespace DaxStudio.UI.Utils
         private static readonly object ProxyLock = new object();
         // Urls
         //Single API that returns formatted DAX as as string and error list (empty formatted DAX string if there are errors)
-        public const string DaxTextFormatUri = "https://www.daxformatter.com/api/daxformatter/DaxTextFormat";
+        public const string DaxTextFormatUri = "https://api.daxformatter.com/api/daxtextformat";
 
 #if DEBUG
         public const string CurrentGithubVersionUrl = "https://raw.githubusercontent.com/DaxStudio/DaxStudio/develop/src/CurrentReleaseVersion.json";

--- a/src/DaxStudio.UI/ViewModels/DocumentViewModel.cs
+++ b/src/DaxStudio.UI/ViewModels/DocumentViewModel.cs
@@ -258,9 +258,6 @@ namespace DaxStudio.UI.ViewModels
             SelectedWorksheet = Properties.Resources.DAX_Results_Sheet;
 
             HelpWatermark = new HelpWatermarkViewModel();
-
-            var t = DaxFormatterProxy.PrimeConnectionAsync(Options, _eventAggregator);
-            t.FireAndForget();
         }
 
         public HelpWatermarkViewModel HelpWatermark { get; set; }


### PR DESCRIPTION
This pull request updates DaxFormatterProxy to use the new DAX Formatter API endpoint, see [sql-bi/DaxFormatter#23](https://github.com/sql-bi/DaxFormatter/pull/23).

The service moved from `www.daxformatter.com/api/daxformatter/` to the new official API host `api.daxformatter.com/api/`.  The new `api.daxformatter.com` host is the direct API endpoint and no longer issues a redirect, so all the redirect-following and connection-priming code has been removed.